### PR TITLE
Fix deprecation warnings by replacing red(), green(), and blue() with color.channel()

### DIFF
--- a/src/global/_functions.scss
+++ b/src/global/_functions.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 // ====================================================
 // Function: convert-to-rgb
 // Description: Converts a color value to its red, green, and blue (RGB) components.
@@ -6,7 +8,9 @@
 // Returns: A comma-separated list of the red, green, and blue values of the color in that order.
 // ====================================================
 @function convert-to-rgb($value) {
-  @return red($value), green($value), blue($value);
+  @return color.channel($value, "red", $space: rgb), color.channel($value, "green", $space: rgb),
+    color.channel($value, "blue", $space: rgb);
+  // @return red($value), green($value), blue($value);
 }
 
 // ====================================================


### PR DESCRIPTION
### **Description:**

Resolved deprecation warnings related to `red()`, `green()`, and `blue()` functions by replacing them with the `color.channel()` function from Sass, ensuring future compatibility.

---

#### **Key Changes:**

1. Replaced deprecated `red()`, `green()`, and `blue()` functions with `color.channel()` for extracting color channels.
2. Ensured compatibility with newer versions of Sass by addressing deprecation warnings.